### PR TITLE
fix: remove `composer.json` from `.github`

### DIFF
--- a/.github/vendor-bin/phpcs/composer.json
+++ b/.github/vendor-bin/phpcs/composer.json
@@ -1,6 +1,0 @@
-{
-  "require-dev": {
-    "squizlabs/php_codesniffer": "^3.7",
-    "dvsa/coding-standards": "^2.0"
-  }
-}


### PR DESCRIPTION
## Description

Remove `composer.json` from `.github` folder. Accident.