### PR TITLE
feat: VOL-3691 switch to Psr Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-servicemanager": "^3.0",
+        "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-filter": "^2.0",
         "laminas/laminas-xml": "^1.2",
         "laminas/laminas-validator": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-filter": "^2.0",
         "laminas/laminas-xml": "^1.2",
-        "laminas/laminas-validator": "^2.0"
+        "laminas/laminas-validator": "^2.0",
+        "psr/container": "^1.1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/src/Validator/XsdFactory.php
+++ b/src/Validator/XsdFactory.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\XmlTools\Validator;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/test/Validator/XsdFactoryTest.php
+++ b/test/Validator/XsdFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace OlcsTest\XmlTools\Validator;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Olcs\XmlTools\Validator\Xsd;
 use Olcs\XmlTools\Validator\XsdFactory;
 use Mockery as m;


### PR DESCRIPTION
BREAKING CHANGE: interop/container no longer supported

## Description

container/interop has been swapped out for the PSR version

Related issue: [VOL-3691](https://dvsa.atlassian.net/browse/VOL-3691)
