### PR TITLE
chore!: update workflow and composer files to minimum PHP 8.2 VOL-6497

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,17 +9,18 @@ jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-library-security.yml@main
     with:
-      php-versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["8.2", "8.3"]'
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
     uses: dvsa/.github/.github/workflows/php-library-static.yml@main
     with:
-      php-version: '8.0'
+      php-version: '8.2'
+      stability: '["prefer-stable"]'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-library-tests.yml@main
     with:
-      php-versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["8.2", "8.3"]'
       fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -2,21 +2,21 @@
     "name": "olcs/olcs-xmltools",
     "description": "XML tools for OLCS",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-servicemanager": "^3.11",
-        "laminas/laminas-filter": "^2.0",
-        "laminas/laminas-xml": "^1.2",
-        "laminas/laminas-validator": "^2.0",
+        "laminas/laminas-stdlib": "^3.20",
+        "laminas/laminas-servicemanager": "^3.23",
+        "laminas/laminas-filter": "^2.41",
+        "laminas/laminas-xml": "^1.7",
+        "laminas/laminas-validator": "^2.64",
         "psr/container": "^1.1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "mockery/mockery": "^1.6",
         "johnkary/phpunit-speedtrap": "^4.0",
-        "bamarni/composer-bin-plugin": "^1.8",
+        "bamarni/composer-bin-plugin": "^1.8.2",
         "mikey179/vfsstream": "^1.6.11",
         "phpstan/phpstan-mockery": "^1.1"
     },

--- a/src/Filter/MapXmlFile.php
+++ b/src/Filter/MapXmlFile.php
@@ -39,6 +39,7 @@ class MapXmlFile extends AbstractFilter
      * @throws Exception\RuntimeException If filtering $value is impossible
      * @return mixed
      */
+    #[\Override]
     public function filter($value, $context = [])
     {
         return $this->getMapping()->apply($value->documentElement);

--- a/src/Filter/ParseXml.php
+++ b/src/Filter/ParseXml.php
@@ -22,6 +22,7 @@ class ParseXml extends AbstractFilter
      * @throws Exception\RuntimeException If filtering $value is impossible
      * @return mixed
      */
+    #[\Override]
     public function filter($value)
     {
         $domDocument = new DOMDocument();

--- a/src/Filter/ParseXmlString.php
+++ b/src/Filter/ParseXmlString.php
@@ -22,6 +22,7 @@ class ParseXmlString extends AbstractFilter
      * @throws Exception\RuntimeException If filtering $value is impossible
      * @return mixed
      */
+    #[\Override]
     public function filter($value)
     {
         $domDocument = new DOMDocument();

--- a/src/Validator/Xsd.php
+++ b/src/Validator/Xsd.php
@@ -116,6 +116,7 @@ class Xsd extends AbstractValidator
      * @return bool
      * @throws Exception\RuntimeException If validation of $value is impossible
      */
+    #[\Override]
     public function isValid($value)
     {
         $this->setValue($value);

--- a/src/Validator/XsdFactory.php
+++ b/src/Validator/XsdFactory.php
@@ -11,6 +11,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
  */
 class XsdFactory implements FactoryInterface
 {
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Xsd
     {
         $config = $container->get('Config');

--- a/src/Xml/ElementIterator.php
+++ b/src/Xml/ElementIterator.php
@@ -10,6 +10,7 @@ class ElementIterator extends \FilterIterator
     /**
      * @template-extends \Iterator<int, \DOMElement>
      */
+    #[\Override]
     public function accept(): bool
     {
         return $this->getInnerIterator()->current() instanceof \DOMElement;

--- a/src/Xml/NodeListIterator.php
+++ b/src/Xml/NodeListIterator.php
@@ -30,6 +30,7 @@ class NodeListIterator implements \Iterator
      * @link http://php.net/manual/en/iterator.current.php
      * @return DOMNode|null Can return any type.
      */
+    #[\Override]
     public function current(): ?DOMNode
     {
         return $this->target->item($this->key());
@@ -41,6 +42,7 @@ class NodeListIterator implements \Iterator
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
      */
+    #[\Override]
     public function next(): void
     {
         ++$this->key;
@@ -52,6 +54,7 @@ class NodeListIterator implements \Iterator
      * @link http://php.net/manual/en/iterator.key.php
      * @return int|null scalar on success, or null on failure.
      */
+    #[\Override]
     public function key(): ?int
     {
         return $this->key;
@@ -64,6 +67,7 @@ class NodeListIterator implements \Iterator
      * @return boolean The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      */
+    #[\Override]
     public function valid(): bool
     {
         return $this->target->length > $this->key;
@@ -75,6 +79,7 @@ class NodeListIterator implements \Iterator
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
      */
+    #[\Override]
     public function rewind(): void
     {
         $this->key = 0;

--- a/src/Xml/Specification/FixedValue.php
+++ b/src/Xml/Specification/FixedValue.php
@@ -31,6 +31,7 @@ class FixedValue extends AbstractCapturingNode
     /**
      * @return mixed
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue($this->getValue());

--- a/src/Xml/Specification/MultiNodeValue.php
+++ b/src/Xml/Specification/MultiNodeValue.php
@@ -19,6 +19,7 @@ class MultiNodeValue extends AbstractCapturingNode
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue([$domElement->nodeValue]);

--- a/src/Xml/Specification/MultiRecursionValue.php
+++ b/src/Xml/Specification/MultiRecursionValue.php
@@ -30,6 +30,7 @@ class MultiRecursionValue extends AbstractCapturingNode
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue([$this->getRecursion()->apply($domElement)]);

--- a/src/Xml/Specification/NodeAttribute.php
+++ b/src/Xml/Specification/NodeAttribute.php
@@ -34,6 +34,7 @@ class NodeAttribute extends AbstractCapturingNode
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue($domElement->getAttribute($this->getProperty()));

--- a/src/Xml/Specification/NodeValue.php
+++ b/src/Xml/Specification/NodeValue.php
@@ -19,6 +19,7 @@ class NodeValue extends AbstractCapturingNode
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue($domElement->nodeValue);

--- a/src/Xml/Specification/Recursion.php
+++ b/src/Xml/Specification/Recursion.php
@@ -41,6 +41,7 @@ class Recursion implements SpecificationInterface
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         $result = [];

--- a/src/Xml/Specification/RecursionAttribute.php
+++ b/src/Xml/Specification/RecursionAttribute.php
@@ -41,6 +41,7 @@ class RecursionAttribute implements SpecificationInterface
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         $result = [];

--- a/src/Xml/Specification/RecursionValue.php
+++ b/src/Xml/Specification/RecursionValue.php
@@ -30,6 +30,7 @@ class RecursionValue extends AbstractCapturingNode
     /**
      * @return array
      */
+    #[\Override]
     public function apply(\DOMElement $domElement)
     {
         return $this->createReturnValue($this->getRecursion()->apply($domElement));

--- a/src/Xml/TagNameFilterIterator.php
+++ b/src/Xml/TagNameFilterIterator.php
@@ -29,6 +29,7 @@ class TagNameFilterIterator extends \FilterIterator
      * @link http://php.net/manual/en/filteriterator.accept.php
      * @return bool true if the current element is acceptable, otherwise false.
      */
+    #[\Override]
     public function accept(): bool
     {
         /** @var \DOMElement $domElement */


### PR DESCRIPTION
## Description

Implements what was discussed in recent technical review:

- static analysis now isn't testing against `prefer-lowest`
- minimum package versions bumped e.g. for Laminas
- PHP version in composer set to `~8.2.0 || ~8.3.0`
- CI runs against 8.2 and 8.3, except static analysis which is still 8.2 only
- Fixes done to get pipeline green

Related issue: [VOL-6497](https://dvsa.atlassian.net/browse/VOL-6497)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6497]: https://dvsa.atlassian.net/browse/VOL-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ