### PR TITLE
chore: bump phpstan and psalm, static analysis now runs on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
   static-analysis:
     uses: dvsa/.github/.github/workflows/php-library-static.yml@main
     with:
-      php-version: '8.2'
+      php-version: '8.3'
       stability: '["prefer-stable"]'
 
   tests:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "johnkary/phpunit-speedtrap": "^4.0",
         "bamarni/composer-bin-plugin": "^1.8.2",
         "mikey179/vfsstream": "^1.6.11",
-        "phpstan/phpstan-mockery": "^1.1"
+        "phpstan/phpstan-mockery": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/vendor-bin/phpcs/composer.json
+++ b/vendor-bin/phpcs/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.13",
     "dvsa/coding-standards": "^2.0"
   }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "phpstan/phpstan": "^1.10"
+    "phpstan/phpstan": "^2.1"
   }
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "vimeo/psalm": "^5.15"
+    "vimeo/psalm": "^6.13"
   }
 }


### PR DESCRIPTION
## Description

Additional PR for this ticket. Bumped phpstan and psalm to new major versions. Static analysis now runs against PHP 8.3.

Related issue: [VOL-6497](https://dvsa.atlassian.net/browse/VOL-6497)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6497]: https://dvsa.atlassian.net/browse/VOL-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ