### PR TITLE
feat: run any numeric-key specs against the current DOM element

### DIFF
--- a/src/Xml/Specification/Recursion.php
+++ b/src/Xml/Specification/Recursion.php
@@ -46,22 +46,37 @@ class Recursion implements SpecificationInterface
     {
         $result = [];
         $specification = $this->getSpecification();
-        $nodeList = $domElement->childNodes;
 
+        // Apply inline specs (numeric keys) to the *current* element
+        foreach ($specification as $key => $instruction) {
+            if (!is_int($key)) {
+                continue;
+            }
+            // $instruction can be a single spec or an array of specs
+            $instructions = is_array($instruction) ? $instruction : [$instruction];
+            foreach ($instructions as $inst) {
+                /** @var SpecificationInterface $inst */
+                $result = ArrayUtils::merge($result, $inst->apply($domElement));
+            }
+        }
+
+        // Recurse into children for string-keyed specs (existing behaviour)
+        // Build the list of tag names to look for (string keys only)
+        $tagNames = array_filter(array_keys($specification), 'is_string');
+
+        $nodeList = $domElement->childNodes;
         $iterator = new NodeListIterator($nodeList);
         $iterator = new ElementIterator($iterator);
         $iterator = new TagNameFilterIterator($iterator, array_keys($specification));
 
         /** @var \DOMElement $element */
         foreach ($iterator as $element) {
-            $spec = $specification[$element->tagName];
-            if (!is_array($spec)) {
-                $spec = [$spec];
-            }
+            $childSpec = $specification[$element->tagName];
+            $childSpecs = is_array($childSpec) ? $childSpec : [$childSpec];
 
-            foreach ($spec as $instruction) {
+            foreach ($childSpecs as $instruction) {
                 /** @var SpecificationInterface $instruction */
-                $result = ArrayUtils::merge($result, $instruction->apply($element));
+                $result = \Laminas\Stdlib\ArrayUtils::merge($result, $instruction->apply($element));
             }
         }
 


### PR DESCRIPTION
## Description

This PR updates Recursion::apply() so that it applies numeric-keyed specifications (such as NodeAttribute) directly to the current DOM element.

## Why

- Previously, apply() only processed string-keyed specs (child elements).
- Numeric-keyed specs were ignored, so attributes like SchemaVersion on the root <TransXChange> were not being captured.

## What changed
**apply() now:**

- Executes numeric-keyed specs on the current node.
- Continues existing behaviour for string-keyed specs (children).

## Impact

- Allows root-level attributes (e.g. SchemaVersion) to be mapped correctly.
- No breaking changes to existing child element mappings.

Related issue: [VOL-6589](https://dvsa.atlassian.net/browse/VOL-6589)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6589]: https://dvsa.atlassian.net/browse/VOL-6589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ