### PR TITLE
feat: allow the parent element to be accessed by the recursion class VOL-6589

### DIFF
--- a/src/Xml/Specification/Recursion.php
+++ b/src/Xml/Specification/Recursion.php
@@ -65,6 +65,12 @@ class Recursion implements SpecificationInterface
             }
         }
 
+        //allows the contents of the root element to also be accessed
+        if (isset($specification[$domElement->tagName])) {
+            $instruction = $specification[$domElement->tagName];
+            $result = ArrayUtils::merge($result, $instruction->apply($domElement));
+        }
+
         return $result;
     }
 }

--- a/test/Xml/Specification/RecursionTest.php
+++ b/test/Xml/Specification/RecursionTest.php
@@ -1,23 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OlcsTest\XmlTools\Xml\Specification;
 
+use Olcs\XmlTools\Xml\Specification\NodeAttribute;
 use Olcs\XmlTools\Xml\Specification\NodeValue;
 use Olcs\XmlTools\Xml\Specification\Recursion;
 
 /**
- * Class RecursionTest
- *
  * Also covers iterator classes used internally by recursion algorithm
- *
- * @package OlcsTest\XmlTools\Xml\Specification
  */
 class RecursionTest extends \PHPUnit\Framework\TestCase
 {
     public function testApply(): void
     {
         $domDocument = new \DOMDocument();
-        $xml = '<Doc><TestTag>Value</TestTag><OtherTag>this is not the value you are looking for</OtherTag></Doc>';
+        $xml = '<Doc SchemaVersion="2.1"><TestTag>Value</TestTag><OtherTag>this is not the value you are looking for</OtherTag></Doc>';
         $domDocument->loadXML($xml);
 
         $recursion = new Recursion(['TestTag' => [new NodeValue('testprop')]]);
@@ -30,7 +29,7 @@ class RecursionTest extends \PHPUnit\Framework\TestCase
     public function testApplyWithShorthands(): void
     {
         $domDocument = new \DOMDocument();
-        $xml = '<Doc><TestTag>Value</TestTag><OtherTag>this is not the value you are looking for</OtherTag></Doc>';
+        $xml = '<Doc SchemaVersion="2.1"><TestTag>Value</TestTag><OtherTag>this is not the value you are looking for</OtherTag></Doc>';
         $domDocument->loadXML($xml);
 
         $recursion = new Recursion('TestTag', new NodeValue('testprop'));
@@ -38,5 +37,28 @@ class RecursionTest extends \PHPUnit\Framework\TestCase
         $result = $recursion->apply($domDocument->documentElement);
 
         $this->assertEquals(['testprop' => 'Value'], $result);
+    }
+
+    public function testApplyWithRootElementAccess(): void
+    {
+        $domDocument = new \DOMDocument();
+        $xml = '<Doc SchemaVersion="2.1"><TestTag>Value</TestTag><OtherTag>this is not the value you are looking for</OtherTag></Doc>';
+        $domDocument->loadXML($xml);
+
+        $recursion = new Recursion(
+            [
+                'TestTag' => new NodeValue('testprop'),
+                'Doc' => new NodeAttribute('txcSchemaVersion', 'SchemaVersion'),
+            ]
+        );
+
+        $result = $recursion->apply($domDocument->documentElement);
+
+        $expected = [
+            'testprop' => 'Value',
+            'txcSchemaVersion' => '2.1',
+        ];
+
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
Related issue: [VOL-6589](https://dvsa.atlassian.net/browse/VOL-6589)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6589]: https://dvsa.atlassian.net/browse/VOL-6589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ